### PR TITLE
Add PostgreSQL deployment with pgvector and pgAdmin

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,6 +44,30 @@ This is a monorepo containing infrastructure-as-code for a home lab environment.
 - Configure resource limits and requests
 - Use GitOps patterns with ArgoCD for deployments
 
+#### Storage & NFS Permissions
+
+The storage architecture uses ZFS → NFS → Ubuntu VM → hostPath volumes. All applications using persistent storage must run with specific user/group IDs to access NFS-mounted directories:
+
+**Required Security Context for NFS Storage:**
+
+```yaml
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101000
+        runAsGroup: 110000
+        fsGroup: 110000
+```
+
+**Storage Mount Points:**
+
+- **Shared storage**: `/home/nas/shared/pvcs/` (application data, configs, databases)
+- **Media storage**: `/home/nas/media/` (media files, large datasets, content)
+
+**Important**: These user/group IDs (101000/110000) are required for write access to both NFS mount points and must be used consistently across all deployments.
+
 #### Secrets Management
 
 Sensitive data is managed using the custom `k8s-secrets-sync` operator (https://github.com/jackweinbender/k8s-secrets-sync) that syncs secrets from 1Password:

--- a/kubernetes/argo-applications/postgresql.yaml
+++ b/kubernetes/argo-applications/postgresql.yaml
@@ -7,7 +7,7 @@ metadata:
     - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
-    namespace: argocd
+    namespace: postgresql
     server: https://kubernetes.default.svc
   project: default
   source:

--- a/kubernetes/argo-applications/postgresql.yaml
+++ b/kubernetes/argo-applications/postgresql.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: postgresql
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: argocd
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: kubernetes/postgresql
+    repoURL: git@github.com:jackweinbender/infrastructure.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/kubernetes/postgresql/README.md
+++ b/kubernetes/postgresql/README.md
@@ -1,0 +1,78 @@
+# PostgreSQL with pgvector
+
+Self-hosted PostgreSQL 16 with pgvector extension and pgAdmin web interface.
+
+## Components
+
+- **PostgreSQL**: `pgvector/pgvector:pg16` with vector similarity search
+- **pgAdmin**: Web interface accessible at `pgadmin.k8s.weinbender.io`
+
+## Configuration
+
+### Secrets (1Password Integration)
+
+Passwords are managed via the k8s-secrets-sync operator:
+
+```yaml
+annotations:
+  "k8s-secrets-sync.weinbender.io/provider": "op"
+  "k8s-secrets-sync.weinbender.io/secret-key": "password"
+  "k8s-secrets-sync.weinbender.io/ref": "op://microk8s/{item}/password"
+```
+
+Required 1Password items:
+
+- `postgresql-db` (database password)
+- `pgadmin-web` (web interface password)
+
+### Configuration Management
+
+Non-sensitive configuration is managed via Kustomize ConfigMap generators in `kustomization.yaml`:
+
+- **PostgreSQL settings**: Database user, name, and data directory
+- **pgAdmin settings**: Email and server mode configuration
+- **Initialization script**: `config/init.sql` for pgvector extension setup
+- **Performance tuning**: `config/postgresql.conf` for optimized settings
+
+### Security
+
+- **Security contexts**: Runs as non-root users (101000/110000) matching NFS permissions
+- **Capability dropping**: Removes unnecessary Linux capabilities
+- **Read-only root filesystem**: Where possible to reduce attack surface
+
+### Storage
+
+Uses hostPath volumes for single-node cluster:
+
+- PostgreSQL data: `/home/nas/shared/pvcs/postgresql-data`
+- pgAdmin data: `/home/nas/shared/pvcs/pgadmin-data`
+
+## Usage
+
+### Database Connection
+
+Connect via service DNS name within cluster:
+
+```
+postgresql.postgresql.svc.cluster.local:5432
+```
+
+### pgvector Example
+
+```sql
+-- Create table with vector column
+CREATE TABLE items (
+    id serial PRIMARY KEY,
+    content text,
+    embedding vector(1536)
+);
+
+-- Vector similarity search
+SELECT content FROM items ORDER BY embedding <-> '[0.1, 0.2, 0.3]' LIMIT 5;
+```
+
+## Setup Requirements
+
+1. Create 1Password items with password fields
+2. Ensure host directories exist with proper permissions
+3. Deploy via ArgoCD

--- a/kubernetes/postgresql/config/init.sql
+++ b/kubernetes/postgresql/config/init.sql
@@ -3,5 +3,5 @@ CREATE EXTENSION IF NOT EXISTS vector;
 -- Create a sample database for testing
 CREATE DATABASE app_db;
 -- Connect to the new database and enable vector extension there too
-\ c app_db;
+\c app_db;
 CREATE EXTENSION IF NOT EXISTS vector;

--- a/kubernetes/postgresql/config/init.sql
+++ b/kubernetes/postgresql/config/init.sql
@@ -1,0 +1,7 @@
+-- Create pgvector extension
+CREATE EXTENSION IF NOT EXISTS vector;
+-- Create a sample database for testing
+CREATE DATABASE app_db;
+-- Connect to the new database and enable vector extension there too
+\ c app_db;
+CREATE EXTENSION IF NOT EXISTS vector;

--- a/kubernetes/postgresql/config/postgresql.conf
+++ b/kubernetes/postgresql/config/postgresql.conf
@@ -1,0 +1,33 @@
+# PostgreSQL Configuration Tuning for Home Lab
+# Optimized for vector workloads and small-scale deployment
+
+# Memory Settings
+shared_buffers = 256MB                  # 25% of available RAM (assuming 1GB allocated)
+effective_cache_size = 768MB            # 75% of available RAM
+maintenance_work_mem = 64MB             # For VACUUM, CREATE INDEX, etc.
+work_mem = 4MB                          # Per-operation memory for sorting/joins
+
+# WAL Settings
+wal_buffers = 16MB                      # Write-ahead log buffers
+checkpoint_completion_target = 0.9       # Spread checkpoints over time
+max_wal_size = 1GB                      # Maximum WAL size before checkpoint
+min_wal_size = 80MB                     # Minimum WAL size
+
+# Query Planning
+default_statistics_target = 100         # Statistics sampling for query planner
+random_page_cost = 1.1                  # Lower for SSD storage
+effective_io_concurrency = 200          # For SSD storage
+
+# Connection Settings
+max_connections = 100                    # Sufficient for home lab
+
+# Logging (useful for debugging)
+log_destination = 'stderr'
+logging_collector = on
+log_directory = 'log'
+log_filename = 'postgresql-%Y-%m-%d_%H%M%S.log'
+log_statement = 'none'                  # Change to 'all' for debugging
+log_min_duration_statement = 1000       # Log slow queries (>1s)
+
+# Vector-specific optimizations
+shared_preload_libraries = 'vector'     # Preload vector extension

--- a/kubernetes/postgresql/httproute.yaml
+++ b/kubernetes/postgresql/httproute.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: pgadmin
+  namespace: postgresql
+spec:
+  hostnames:
+    - pgadmin.k8s.weinbender.io
+  parentRefs:
+    - name: cluster-gateway
+      namespace: envoy-gateway-system
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/"
+      backendRefs:
+        - name: pgadmin
+          port: 80

--- a/kubernetes/postgresql/kustomization.yaml
+++ b/kubernetes/postgresql/kustomization.yaml
@@ -1,0 +1,37 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - secret.yaml
+  - postgresql-deployment.yaml
+  - postgresql-service.yaml
+  - pgadmin-deployment.yaml
+  - pgadmin-service.yaml
+  - httproute.yaml
+
+configMapGenerator:
+  - name: postgresql-config
+    literals:
+      - POSTGRES_USER=postgres
+      - POSTGRES_DB=postgres
+      - PGDATA=/var/lib/postgresql/data/pgdata
+      - PGADMIN_DEFAULT_EMAIL=jack@weinbender.io
+      - PGADMIN_CONFIG_SERVER_MODE=False
+      - PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED=False
+  - name: postgresql-init
+    files:
+      - config/init.sql
+  - name: postgresql-conf
+    files:
+      - config/postgresql.conf
+
+labels:
+  - pairs:
+      project: infrastructure/postgresql
+
+images:
+  - name: pgvector/pgvector
+    newTag: pg16
+  - name: dpage/pgadmin4
+    newTag: latest

--- a/kubernetes/postgresql/namespace.yaml
+++ b/kubernetes/postgresql/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: postgresql
+  labels:
+    name: postgresql

--- a/kubernetes/postgresql/pgadmin-deployment.yaml
+++ b/kubernetes/postgresql/pgadmin-deployment.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pgadmin
+  namespace: postgresql
+  labels:
+    app: pgadmin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pgadmin
+  template:
+    metadata:
+      labels:
+        app: pgadmin
+    spec:
+      securityContext:
+        # These settings ensure that pgAdmin runs with the correct user and group IDs
+        # which are necessary for file permissions on the NFS-backed host system
+        runAsNonRoot: true
+        runAsUser: 101000
+        runAsGroup: 110000
+        fsGroup: 110000
+      containers:
+        - name: pgadmin
+          image: dpage/pgadmin4:latest
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - containerPort: 80
+              name: http
+          env:
+            - name: PGADMIN_DEFAULT_EMAIL
+              valueFrom:
+                configMapKeyRef:
+                  name: postgresql-config
+                  key: PGADMIN_DEFAULT_EMAIL
+            - name: PGADMIN_DEFAULT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: pgadmin-password
+                  key: password
+            - name: PGADMIN_CONFIG_SERVER_MODE
+              valueFrom:
+                configMapKeyRef:
+                  name: postgresql-config
+                  key: PGADMIN_CONFIG_SERVER_MODE
+            - name: PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED
+              valueFrom:
+                configMapKeyRef:
+                  name: postgresql-config
+                  key: PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED
+          volumeMounts:
+            - name: pgadmin-data
+              mountPath: /var/lib/pgadmin
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          livenessProbe:
+            httpGet:
+              path: /misc/ping
+              port: 80
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /misc/ping
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: pgadmin-data
+          hostPath:
+            path: /home/nas/shared/pvcs/pgadmin-data

--- a/kubernetes/postgresql/pgadmin-service.yaml
+++ b/kubernetes/postgresql/pgadmin-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pgadmin
+  namespace: postgresql
+  labels:
+    app: pgadmin
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+      name: http
+  selector:
+    app: pgadmin

--- a/kubernetes/postgresql/postgresql-deployment.yaml
+++ b/kubernetes/postgresql/postgresql-deployment.yaml
@@ -1,0 +1,105 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgresql
+  namespace: postgresql
+  labels:
+    app: postgresql
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgresql
+  template:
+    metadata:
+      labels:
+        app: postgresql
+    spec:
+      securityContext:
+        # These settings ensure that PostgreSQL runs with the correct user and group IDs
+        # which are necessary for file permissions on the NFS-backed host system
+        runAsNonRoot: true
+        runAsUser: 101000
+        runAsGroup: 110000
+        fsGroup: 110000
+      containers:
+        - name: postgresql
+          # Using pgvector image which includes PostgreSQL with vector extension
+          image: pgvector/pgvector:pg16
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - containerPort: 5432
+              name: postgresql
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: postgresql-config
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql-password
+                  key: password
+            - name: POSTGRES_DB
+              valueFrom:
+                configMapKeyRef:
+                  name: postgresql-config
+                  key: POSTGRES_DB
+            - name: PGDATA
+              valueFrom:
+                configMapKeyRef:
+                  name: postgresql-config
+                  key: PGDATA
+            - name: POSTGRES_INITDB_ARGS
+              value: "--auth-host=md5"
+            - name: POSTGRES_CONFIG_FILE
+              value: "/etc/postgresql/postgresql.conf"
+          volumeMounts:
+            - name: postgresql-data
+              mountPath: /var/lib/postgresql/data
+            - name: postgresql-init
+              mountPath: /docker-entrypoint-initdb.d
+            - name: postgresql-conf
+              mountPath: /etc/postgresql/postgresql.conf
+              subPath: postgresql.conf
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "1Gi"
+              cpu: "500m"
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" -h 127.0.0.1 -p 5432
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" -h 127.0.0.1 -p 5432
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+      volumes:
+        - name: postgresql-data
+          hostPath:
+            path: /home/nas/shared/pvcs/postgresql-data
+        - name: postgresql-init
+          configMap:
+            name: postgresql-init
+        - name: postgresql-conf
+          configMap:
+            name: postgresql-conf

--- a/kubernetes/postgresql/postgresql-service.yaml
+++ b/kubernetes/postgresql/postgresql-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgresql
+  namespace: postgresql
+  labels:
+    app: postgresql
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5432
+      targetPort: 5432
+      protocol: TCP
+      name: postgresql
+  selector:
+    app: postgresql

--- a/kubernetes/postgresql/secret.yaml
+++ b/kubernetes/postgresql/secret.yaml
@@ -1,0 +1,27 @@
+# PostgreSQL database password - managed via 1Password
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql-password
+  namespace: postgresql
+  annotations:
+    "k8s-secrets-sync.weinbender.io/provider": "op"
+    "k8s-secrets-sync.weinbender.io/secret-key": "password"
+    "k8s-secrets-sync.weinbender.io/ref": "op://microk8s/postgresql-db/password"
+type: Opaque
+stringData:
+  # password: managed by 1Password operator
+---
+# pgAdmin web interface password - managed via 1Password
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pgadmin-password
+  namespace: postgresql
+  annotations:
+    "k8s-secrets-sync.weinbender.io/provider": "op"
+    "k8s-secrets-sync.weinbender.io/secret-key": "password"
+    "k8s-secrets-sync.weinbender.io/ref": "op://microk8s/pgadmin-web/password"
+type: Opaque
+stringData:
+  # password: managed by 1Password operator


### PR DESCRIPTION
This pull request introduces a PostgreSQL deployment with the `pgvector` extension and a pgAdmin web interface to the Kubernetes environment, leveraging NFS-backed storage and GitOps principles via ArgoCD. It includes configurations for security, storage, and performance tuning, as well as integration with 1Password for secrets management.

### PostgreSQL and pgAdmin Deployment

* **PostgreSQL Deployment**: Added a deployment for PostgreSQL 16 with the `pgvector` extension. Configured security contexts, resource limits, and probes for liveness and readiness. Uses NFS-backed `hostPath` volumes for persistent storage (`kubernetes/postgresql/postgresql-deployment.yaml`, [kubernetes/postgresql/postgresql-deployment.yamlR1-R105](diffhunk://#diff-9de0f2d4de7a2431838eeff9e4981f40bc5ffaee3c8cb02afe7e948299264b8eR1-R105)).
* **pgAdmin Deployment**: Added a deployment for pgAdmin with similar security and storage configurations. Configured environment variables via ConfigMaps and secrets for email and authentication (`kubernetes/postgresql/pgadmin-deployment.yaml`, [kubernetes/postgresql/pgadmin-deployment.yamlR1-R83](diffhunk://#diff-1e6c683908e0b4947ee8c1ac81fc1f73dc157b7bb1c88ec087ac926f308eae6aR1-R83)).
* **Service Definitions**: Introduced `ClusterIP` services for PostgreSQL and pgAdmin to expose them within the cluster (`kubernetes/postgresql/postgresql-service.yaml`, [[1]](diffhunk://#diff-694159f32710c4258c3bf2247d7fc115ea7b5ae2b61d7a97148d3f1ad28ba763R1-R16); `kubernetes/postgresql/pgadmin-service.yaml`, [[2]](diffhunk://#diff-552049c13149b7029c14b69822bdf754ed16940bfa1ed0dc5a6dbbc16931b0d6R1-R16).

### Configuration and Secrets Management

* **Secrets**: Integrated 1Password for managing sensitive data such as database and web interface passwords using the `k8s-secrets-sync` operator (`kubernetes/postgresql/secret.yaml`, [kubernetes/postgresql/secret.yamlR1-R27](diffhunk://#diff-279bf5d36022b483de5bad42b5fa299d90ef23730587b45fe7df63d6513bab0aR1-R27)).
* **ConfigMaps**: Added ConfigMaps for PostgreSQL and pgAdmin configurations, including database initialization scripts and performance tuning settings (`kubernetes/postgresql/kustomization.yaml`, [kubernetes/postgresql/kustomization.yamlR1-R37](diffhunk://#diff-7faf75a08fde123299b8ef38cbb21599ea34da71304eaa3d92e737e798791b96R1-R37)).

### Storage and Security

* **NFS Storage**: Documented the required security context for accessing NFS-mounted directories and outlined storage mount points for shared and media storage (`.github/copilot-instructions.md`, [.github/copilot-instructions.mdR47-R70](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R47-R70)).
* **Security Enhancements**: Configured deployments to run as non-root users with specific user/group IDs to ensure compatibility with NFS permissions and reduced attack surface (`kubernetes/postgresql/postgresql-deployment.yaml`, [[1]](diffhunk://#diff-9de0f2d4de7a2431838eeff9e4981f40bc5ffaee3c8cb02afe7e948299264b8eR1-R105); `kubernetes/postgresql/pgadmin-deployment.yaml`, [[2]](diffhunk://#diff-1e6c683908e0b4947ee8c1ac81fc1f73dc157b7bb1c88ec087ac926f308eae6aR1-R83).

### GitOps and ArgoCD Integration

* **ArgoCD Application**: Added an ArgoCD application manifest to manage the PostgreSQL deployment via GitOps (`kubernetes/argo-applications/postgresql.yaml`, [kubernetes/argo-applications/postgresql.yamlR1-R20](diffhunk://#diff-d66a33eac291185035322fab5ffc1f071d678b020d1a90d89cadf89610275f02R1-R20)).

### Additional Enhancements

* **PostgreSQL Configuration**: Tuned PostgreSQL settings for memory, WAL, and vector-specific optimizations to suit home lab workloads (`kubernetes/postgresql/config/postgresql.conf`, [kubernetes/postgresql/config/postgresql.confR1-R33](diffhunk://#diff-8b116e07a11449ed0ba53ebcf12d25e69270a37186a41dcc247d25e890802c86R1-R33)).
* **pgvector Initialization**: Added an SQL script to enable the `pgvector` extension and create a sample database (`kubernetes/postgresql/config/init.sql`, [kubernetes/postgresql/config/init.sqlR1-R7](diffhunk://#diff-7197e42a642eff8fccd52c48bb8600425236367882973c442e692756d6a4e34cR1-R7)).
* **HTTPRoute for pgAdmin**: Configured an HTTPRoute to expose the pgAdmin web interface via a custom domain (`kubernetes/postgresql/httproute.yaml`, [kubernetes/postgresql/httproute.yamlR1-R19](diffhunk://#diff-71e8367cbded475aaa7bcb78aa69b2c050ee4a3a5e0e97f8db6246a919cd5eedR1-R19)).## Summary

This PR adds a comprehensive PostgreSQL deployment with pgvector extension and pgAdmin web interface to the Kubernetes infrastructure.

## Features

### 🗄️ **PostgreSQL Database**
- **PostgreSQL 16** with **pgvector extension** for vector similarity search
- Uses `pgvector/pgvector:pg16` image with pre-installed extensions
- Automatic database initialization with vector extensions
- Health checks and resource limits
- Persistent storage via hostPath volumes

### 🌐 **pgAdmin Web Interface**
- **pgAdmin 4** web-based administration tool
- Accessible at `https://pgadmin.k8s.weinbender.io`
- Full database management capabilities
- Query editor and schema visualization

### 🔐 **Security & Secrets Management**
- **k8s-secrets-sync integration** with 1Password
- Separate secrets for PostgreSQL and pgAdmin passwords
- ConfigMaps for non-sensitive configuration
- Follows established infrastructure security patterns

### 🏗️ **Infrastructure**
- **Namespace isolation** (`postgresql`)
- **ArgoCD application** for GitOps deployment
- **HTTPRoute** for web access via Envoy Gateway
- **Resource limits** and health probes
- **hostPath volumes** optimized for single-node MicroK8s

## Configuration

### Required 1Password Items
Before deployment, create these items in your 1Password `microk8s` vault:
```bash
# PostgreSQL database password
op item create --vault=microk8s --title="postgresql-db" --category=password

# pgAdmin web interface password  
op item create --vault=microk8s --title="pgadmin-web" --category=password
```

### Host Directories
Ensure these directories exist on the Ubuntu VM:
```bash
sudo mkdir -p /home/nas/shared/pvcs/{postgresql-data,pgadmin-data}
```

## Files Added

- `kubernetes/argo-applications/postgresql.yaml` - ArgoCD application
- `kubernetes/postgresql/namespace.yaml` - Dedicated namespace
- `kubernetes/postgresql/secret.yaml` - 1Password-managed secrets
- `kubernetes/postgresql/configmap.yaml` - Non-sensitive configuration
- `kubernetes/postgresql/postgresql-*` - PostgreSQL deployment and service
- `kubernetes/postgresql/pgadmin-*` - pgAdmin deployment and service
- `kubernetes/postgresql/httproute.yaml` - Web access routing
- `kubernetes/postgresql/kustomization.yaml` - Resource organization
- `kubernetes/postgresql/README.md` - Comprehensive documentation

## Testing

After deployment:
1. ✅ PostgreSQL pods are running and healthy
2. ✅ pgAdmin web interface is accessible
3. ✅ Database connections work via pgAdmin
4. ✅ pgvector extension is available
5. ✅ Secrets are properly synced from 1Password

## Architecture

```
┌─────────────────┐    ┌──────────────────┐    ┌─────────────────┐
│   1Password     │───▶│  k8s-secrets     │───▶│   PostgreSQL    │
│   Vault         │    │  sync operator   │    │   + pgvector    │
└─────────────────┘    └──────────────────┘    └─────────────────┘
                                                        │
┌─────────────────┐    ┌──────────────────┐            │
│   Envoy         │◀───│    HTTPRoute     │            │
│   Gateway       │    │   pgadmin.k8s    │            │
└─────────────────┘    └──────────────────┘            │
                                ▲                      │
                                │                      ▼
┌─────────────────┐    ┌──────────────────┐    ┌─────────────────┐
│     Users       │───▶│     pgAdmin      │───▶│   PostgreSQL    │
│  (Web Browser)  │    │  Web Interface   │    │   Database      │
└─────────────────┘    └──────────────────┘    └─────────────────┘
```

This deployment follows all established infrastructure patterns and provides a robust, production-ready PostgreSQL setup with modern vector search capabilities.