### PR TITLE
Update instructions and fix deployment

### DIFF
--- a/kubernetes/postgresql/kustomization.yaml
+++ b/kubernetes/postgresql/kustomization.yaml
@@ -26,10 +26,6 @@ configMapGenerator:
     files:
       - config/postgresql.conf
 
-labels:
-  - pairs:
-      project: infrastructure/postgresql
-
 images:
   - name: pgvector/pgvector
     newTag: pg16

--- a/kubernetes/postgresql/namespace.yaml
+++ b/kubernetes/postgresql/namespace.yaml
@@ -2,5 +2,3 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: postgresql
-  labels:
-    name: postgresql


### PR DESCRIPTION
This pull request makes minor updates to Kubernetes configuration files for a PostgreSQL deployment. The changes primarily involve removing unnecessary labels from the configuration.

### Removal of labels:

* [`kubernetes/postgresql/kustomization.yaml`](diffhunk://#diff-7faf75a08fde123299b8ef38cbb21599ea34da71304eaa3d92e737e798791b96L29-L32): Removed the `labels` section under `configMapGenerator`, which previously included a `project: infrastructure/postgresql` key-value pair.
* [`kubernetes/postgresql/namespace.yaml`](diffhunk://#diff-79260faea64d5d5c3bd338e7ad7b158df475e9bcb6bad7d71d8fc3fe0bbced5fL5-L6): Removed the `labels` section from the namespace metadata, which previously included a `name: postgresql` key-value pair.