### PR TITLE
Add shared redis

### DIFF
--- a/kubernetes/argo-applications/redis.yaml
+++ b/kubernetes/argo-applications/redis.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: redis
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/part-of: infrastructure
+spec:
+  project: infrastructure
+  source:
+    repoURL: https://github.com/jackweinbender/infrastructure
+    targetRevision: HEAD
+    path: kubernetes/redis
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: redis
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+      - Validate=true
+      - PruneLast=true
+    automated:
+      prune: true
+      selfHeal: true

--- a/kubernetes/redis/README.md
+++ b/kubernetes/redis/README.md
@@ -1,0 +1,263 @@
+# Redis Infrastructure
+
+This directory contains the shared Redis deployment for the homelab infrastructure. Redis is configured with authentication and ACL-based user isolation to securely serve multiple applications.
+
+## Overview
+
+- **Single shared instance** for resource efficiency
+- **Password + ACL authentication** for security
+- **Per-application user isolation** with database separation
+- **1Password integration** with **centralized password management**
+- **Persistent storage** on NFS-backed volumes
+
+## How Authentication Works
+
+**Password Synchronization Flow:**
+
+1. **1Password**: Stores all user passwords in centralized vaults
+2. **k8s-secrets-sync**: Syncs passwords to **both** Redis namespace and application namespaces
+3. **Redis Init Container**: Reads passwords from Redis namespace and builds ACL file
+4. **Applications**: Read the **same passwords** from their namespace to authenticate
+
+**Key Point**: Both Redis and applications get the **same password** from 1Password, ensuring authentication works.
+
+## Architecture
+
+### Authentication & Authorization
+
+**Admin User:**
+
+- Username: `admin`
+- Access: Full Redis access (all commands, all databases)
+- Use: Maintenance, monitoring, troubleshooting
+
+**Application Users:**
+
+- Username: `{app-name}` (e.g., `immich`)
+- Access: Limited to specific database number
+- Restricted: Cannot use dangerous commands
+- Isolated: Cannot access other application databases
+
+### Database Allocation
+
+| Database | Application | Status                   |
+| -------- | ----------- | ------------------------ |
+| 0        | Immich      | ✅ Active                |
+| 1        | Available   | 🔄 Reserved for next app |
+| 2-15     | Available   | 🔄 Future use            |
+
+## Secrets Management
+
+All Redis passwords are managed via 1Password using the `k8s-secrets-sync` operator:
+
+### Required 1Password Entries
+
+1. **Admin Password:**
+
+   - Vault: `microk8s`
+   - Item: `redis`
+   - Field: `admin-password`
+   - Reference: `op://microk8s/redis/admin-password`
+
+2. **Application Passwords:**
+   - Vault: `microk8s`
+   - Item: `redis-users`
+   - Field: `{app-name}-password` (e.g., `immich-password`)
+   - Reference: `op://microk8s/redis-users/{app-name}-password`
+
+## Adding a New Application
+
+### 1. Update Redis ACL Configuration
+
+Edit `configmap.yaml` and add a new user to the `users.acl` section:
+
+```acl
+# Example for a new app called "myapp"
+user myapp on >MYAPP_PASSWORD_PLACEHOLDER ~* &* +@all -@dangerous +select|2
+```
+
+**ACL Breakdown:**
+
+- `user myapp` - Username
+- `on` - User is enabled
+- `>MYAPP_PASSWORD_PLACEHOLDER` - Password placeholder (replaced at runtime)
+- `~*` - Can access any key pattern
+- `&*` - Can access any pub/sub channel
+- `+@all -@dangerous` - All commands except dangerous ones
+- `+select|2` - Can only SELECT database 2
+
+### 2. Create 1Password Entry
+
+Create a new password in 1Password:
+
+- Vault: `microk8s`
+- Item: `redis-users`
+- Field: `myapp-password`
+- Generate a strong password
+
+### 3. Create Secrets in BOTH Namespaces
+
+The **same password** must be available in both the Redis namespace (for ACL configuration) and the application namespace (for authentication).
+
+**In Redis namespace:**
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redis-myapp-user
+  namespace: redis # Redis namespace
+  annotations:
+    "k8s-secrets-sync.weinbender.io/provider": "op"
+    "k8s-secrets-sync.weinbender.io/secret-key": "password"
+    "k8s-secrets-sync.weinbender.io/ref": "op://microk8s/redis-users/myapp-password"
+type: Opaque
+```
+
+**In Application namespace:**
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: myapp-redis-auth
+  namespace: myapp # Your app's namespace
+  annotations:
+    "k8s-secrets-sync.weinbender.io/provider": "op"
+    "k8s-secrets-sync.weinbender.io/secret-key": "password"
+    "k8s-secrets-sync.weinbender.io/ref": "op://microk8s/redis-users/myapp-password"
+type: Opaque
+```
+
+### 4. Update Redis Deployment
+
+Add the new user secret to Redis deployment volumes and init container:
+
+**Add to init container script:**
+
+```bash
+sed "s/MYAPP_PASSWORD_PLACEHOLDER/$(cat /secrets/myapp-password/password)/" /tmp/users.acl.tmp2 > /tmp/users.acl.tmp3
+```
+
+**Add volume mount:**
+
+```yaml
+- name: myapp-password
+  mountPath: /secrets/myapp-password
+```
+
+**Add volume:**
+
+```yaml
+- name: myapp-password
+  secret:
+    secretName: redis-myapp-user
+```
+
+### 5. Configure Application
+
+Configure your application with environment variables:
+
+```yaml
+env:
+  - name: REDIS_HOSTNAME
+    value: "redis.redis.svc.cluster.local"
+  - name: REDIS_PORT
+    value: "6379"
+  - name: REDIS_USERNAME
+    value: "myapp"
+  - name: REDIS_DBINDEX
+    value: "2" # Next available database number
+  - name: REDIS_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: myapp-redis-auth
+        key: password
+```
+
+## Operations
+
+### Connecting to Redis
+
+**As Admin (for troubleshooting):**
+
+```bash
+# Get admin password
+kubectl get secret redis-auth -n redis -o jsonpath='{.data.password}' | base64 -d
+
+# Connect with password
+kubectl exec -it deployment/redis -n redis -- redis-cli -a <admin-password>
+
+# Or using auth command
+kubectl exec -it deployment/redis -n redis -- redis-cli
+127.0.0.1:6379> AUTH admin <admin-password>
+```
+
+**As Application User:**
+
+```bash
+kubectl exec -it deployment/redis -n redis -- redis-cli -u redis://immich:<password>@localhost:6379/0
+```
+
+### Monitoring
+
+**Check user permissions:**
+
+```bash
+# List all users
+127.0.0.1:6379> ACL LIST
+
+# Check specific user
+127.0.0.1:6379> ACL GETUSER immich
+```
+
+**Database usage:**
+
+```bash
+# Select database and check info
+127.0.0.1:6379> SELECT 0
+127.0.0.1:6379> INFO keyspace
+```
+
+### Troubleshooting
+
+**Common Issues:**
+
+1. **Authentication failures:**
+
+   - Check if secrets are synced: `kubectl get secrets -n redis`
+   - Verify ACL file was created: `kubectl exec deployment/redis -n redis -- cat /etc/redis/users.acl`
+
+2. **Permission denied:**
+
+   - User trying to access wrong database
+   - User trying to run restricted commands
+   - Check ACL: `ACL GETUSER <username>`
+
+3. **Connection issues:**
+   - Verify service: `kubectl get svc redis -n redis`
+   - Check pod status: `kubectl get pods -n redis`
+   - Review logs: `kubectl logs deployment/redis -n redis`
+
+## Configuration Files
+
+- `configmap.yaml` - Redis configuration and ACL rules
+- `secrets.yaml` - User password secrets (1Password managed)
+- `deployment.yaml` - Redis deployment with init container
+- `service.yaml` - ClusterIP service for internal access
+- `kustomization.yaml` - Resource organization
+
+## Security Considerations
+
+- Default user is disabled
+- All access requires authentication
+- Users isolated to specific databases
+- Dangerous commands restricted for app users
+- Protected mode enabled
+- Secrets managed via 1Password integration
+
+## Storage
+
+- Data persisted to `/home/nas/shared/pvcs/redis`
+- NFS-backed storage with proper permissions (101000:110000)
+- Redis save configuration for durability

--- a/kubernetes/redis/configmap.yaml
+++ b/kubernetes/redis/configmap.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-config
+  namespace: redis
+  labels:
+    app: redis
+data:
+  redis.conf: |
+    # Basic configuration
+    bind 0.0.0.0
+    port 6379
+
+    # Memory configuration
+    maxmemory 512mb
+    maxmemory-policy allkeys-lru
+
+    # Database configuration
+    databases 16
+
+    # Security - Require AUTH
+    protected-mode yes
+
+    # ACL configuration file
+    aclfile /etc/redis/users.acl
+
+    # Persistence (optional - for data durability)
+    save 900 1
+    save 300 10
+    save 60 10000
+
+    # Logging
+    loglevel notice
+
+  users.acl: |
+    # Default user (disabled for security)
+    user default off
+
+    # Admin user - full access
+    user admin on >ADMIN_PASSWORD_PLACEHOLDER ~* &* +@all
+
+    # Immich user - limited to database 0
+    user immich on >IMMICH_PASSWORD_PLACEHOLDER ~* &* +@all -@dangerous +select|0

--- a/kubernetes/redis/deployment.yaml
+++ b/kubernetes/redis/deployment.yaml
@@ -1,0 +1,102 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: redis
+  labels:
+    app: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101000
+        runAsGroup: 110000
+        fsGroup: 110000
+      initContainers:
+        - name: setup-acl
+          image: busybox:latest
+          command:
+            - sh
+            - -c
+            - |
+              # Copy config files and substitute passwords
+              cp /config-template/redis.conf /config/redis.conf
+              # Copy ACL template and replace all passwords
+              sed "s/ADMIN_PASSWORD_PLACEHOLDER/$(cat /secrets/admin-password/password)/" /config-template/users.acl > /tmp/users.acl.tmp
+              sed "s/IMMICH_PASSWORD_PLACEHOLDER/$(cat /secrets/immich-password/password)/" /tmp/users.acl.tmp > /config/users.acl
+              rm /tmp/users.acl.tmp
+          volumeMounts:
+            - name: redis-config-template
+              mountPath: /config-template
+            - name: redis-config
+              mountPath: /config
+            - name: admin-password
+              mountPath: /secrets/admin-password
+            - name: immich-password
+              mountPath: /secrets/immich-password
+      containers:
+        - name: redis
+          image: docker.io/valkey/valkey:8-bookworm
+          ports:
+            - containerPort: 6379
+              name: redis
+          command:
+            - valkey-server
+            - /etc/redis/redis.conf
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "1Gi"
+              cpu: "500m"
+          volumeMounts:
+            - name: redis-data
+              mountPath: /data
+            - name: redis-config
+              mountPath: /etc/redis
+            - name: admin-password
+              mountPath: /secrets/admin-password
+          env:
+            - name: REDIS_ARGS
+              value: "--protected-mode yes"
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - "redis-cli -a $(cat /secrets/admin-password/password) ping"
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - "redis-cli -a $(cat /secrets/admin-password/password) ping"
+            initialDelaySeconds: 10
+            periodSeconds: 5
+      volumes:
+        - name: redis-data
+          hostPath:
+            path: /home/nas/shared/pvcs/redis
+            type: DirectoryOrCreate
+        - name: redis-config-template
+          configMap:
+            name: redis-config
+        - name: redis-config
+          emptyDir: {}
+        - name: admin-password
+          secret:
+            secretName: redis-auth
+        - name: immich-password
+          secret:
+            secretName: redis-immich-user

--- a/kubernetes/redis/kustomization.yaml
+++ b/kubernetes/redis/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: redis
+
+resources:
+  - configmap.yaml
+  - secrets.yaml
+  - deployment.yaml
+  - service.yaml
+
+commonLabels:
+  app.kubernetes.io/name: redis
+  app.kubernetes.io/part-of: infrastructure

--- a/kubernetes/redis/secrets.yaml
+++ b/kubernetes/redis/secrets.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redis-auth
+  namespace: redis
+  annotations:
+    "k8s-secrets-sync.weinbender.io/provider": "op"
+    "k8s-secrets-sync.weinbender.io/secret-key": "password"
+    "k8s-secrets-sync.weinbender.io/ref": "op://microk8s/redis/admin-password"
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redis-immich-user
+  namespace: redis
+  annotations:
+    "k8s-secrets-sync.weinbender.io/provider": "op"
+    "k8s-secrets-sync.weinbender.io/secret-key": "password"
+    "k8s-secrets-sync.weinbender.io/ref": "op://microk8s/redis-users/immich-password"
+type: Opaque

--- a/kubernetes/redis/service.yaml
+++ b/kubernetes/redis/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: redis
+  labels:
+    app: redis
+spec:
+  selector:
+    app: redis
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: 6379
+      protocol: TCP
+  type: ClusterIP


### PR DESCRIPTION
This pull request introduces a comprehensive Redis infrastructure deployment for the homelab environment, focusing on security, scalability, and integration with Kubernetes and 1Password for centralized secrets management. The key changes include the addition of Redis configuration files, deployment manifests, and documentation for setup and operations.

### Redis Deployment and Configuration:
* [`kubernetes/argo-applications/redis.yaml`](diffhunk://#diff-96eb363f9ebd6b619128d0f3c4df2b51aa89e3da6c6d02e3ddacfae99cddfe7cR1-R26): Added an ArgoCD `Application` manifest to manage the Redis deployment, enabling automated synchronization and namespace creation.
* [`kubernetes/redis/configmap.yaml`](diffhunk://#diff-30e62adb33d69c1c9424d888ac686c08f2221f009c47c177698d36993dcb04eeR1-R43): Added Redis configuration with ACL rules, memory limits, persistence settings, and security features such as protected mode and authentication.
* [`kubernetes/redis/deployment.yaml`](diffhunk://#diff-a85c2c77ac4463b22c87f5f4feffb4af1d0fa29d8df3b9e7b2ec5b1e98d8758bR1-R102): Defined the Redis deployment with init containers for ACL setup, persistent storage, resource limits, and liveness/readiness probes.
* [`kubernetes/redis/service.yaml`](diffhunk://#diff-47bdee0e15e51f0cc534850b677c7cd2273a89badee8d5fca67297da80cfc291R1-R16): Added a `ClusterIP` service for internal Redis access within the Kubernetes cluster.

### Secrets Management:
* [`kubernetes/redis/secrets.yaml`](diffhunk://#diff-c119861c04016d657c785a6cbf19e170bf2d21a39bc31faab11f79ae55543617R1-R21): Added Kubernetes secrets for Redis admin and application user passwords, integrated with 1Password for secure synchronization.

### Documentation and Organization:
* [`kubernetes/redis/README.md`](diffhunk://#diff-a9b3f41a0f0be3623a8cb565e08194781c92c08e3ff5dd84c10805ef8f904792R1-R263): Provided detailed documentation on Redis architecture, authentication flow, secrets management, and operational procedures, including troubleshooting and security considerations.
* [`kubernetes/redis/kustomization.yaml`](diffhunk://#diff-38e69ce667855e35e6014a59ed38f4f2afc7687668c045134bbab4af4315f6b7R1-R14): Added a `Kustomization` file to organize resources and apply common labels for the Redis namespace.