### PR TITLE
Add Immich

### DIFF
--- a/kubernetes/argo-applications/immich.yaml
+++ b/kubernetes/argo-applications/immich.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: immich
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: immich
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: kubernetes/immich
+    repoURL: git@github.com:jackweinbender/infrastructure.git
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+      - Validate=true
+      - PruneLast=true
+    automated:
+      prune: true
+      selfHeal: true

--- a/kubernetes/immich/configmap.yaml
+++ b/kubernetes/immich/configmap.yaml
@@ -3,8 +3,6 @@ kind: ConfigMap
 metadata:
   name: immich-config
   namespace: immich
-  labels:
-    app: immich
 data:
   # Database configuration
   DB_HOSTNAME: "postgresql.postgresql.svc.cluster.local"

--- a/kubernetes/immich/configmap.yaml
+++ b/kubernetes/immich/configmap.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: immich-config
+  namespace: immich
+  labels:
+    app: immich
+data:
+  # Database configuration
+  DB_HOSTNAME: "postgresql.postgresql.svc.cluster.local"
+  DB_USERNAME: "immich"
+  DB_DATABASE_NAME: "immich"
+  DB_PORT: "5432"
+
+  # Redis configuration
+  REDIS_HOSTNAME: "redis.redis.svc.cluster.local"
+  REDIS_PORT: "6379"
+  REDIS_DBINDEX: "0" # Use database 0 for Immich
+  REDIS_USERNAME: "immich"
+
+  # Machine Learning configuration
+  IMMICH_MACHINE_LEARNING_URL: "http://immich-machine-learning:3003"
+
+  # Logging
+  LOG_LEVEL: "verbose"
+
+  # Server configuration
+  IMMICH_PORT: "2283"
+  IMMICH_ENV: "production"

--- a/kubernetes/immich/deployment-ml.yaml
+++ b/kubernetes/immich/deployment-ml.yaml
@@ -1,0 +1,80 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: immich-machine-learning
+  namespace: immich
+  labels:
+    app: immich-machine-learning
+    component: ml
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: immich-machine-learning
+      component: ml
+  template:
+    metadata:
+      labels:
+        app: immich-machine-learning
+        component: ml
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101000
+        runAsGroup: 110000
+        fsGroup: 110000
+      containers:
+        - name: immich-machine-learning
+          image: ghcr.io/immich-app/immich-machine-learning:release
+          ports:
+            - containerPort: 3003
+              name: http
+          env:
+            - name: LOG_LEVEL
+              value: "verbose"
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "500m"
+            limits:
+              memory: "4Gi"
+              cpu: "2"
+          volumeMounts:
+            - name: model-cache
+              mountPath: /cache
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: 3003
+            initialDelaySeconds: 60
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: 3003
+            initialDelaySeconds: 30
+            periodSeconds: 10
+      volumes:
+        - name: model-cache
+          hostPath:
+            path: /home/nas/shared/pvcs/immich/ml-cache
+            type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: immich-machine-learning
+  namespace: immich
+  labels:
+    app: immich-machine-learning
+    component: ml
+spec:
+  selector:
+    app: immich-machine-learning
+    component: ml
+  ports:
+    - name: http
+      port: 3003
+      targetPort: 3003
+      protocol: TCP
+  type: ClusterIP

--- a/kubernetes/immich/deployment-ml.yaml
+++ b/kubernetes/immich/deployment-ml.yaml
@@ -3,20 +3,15 @@ kind: Deployment
 metadata:
   name: immich-machine-learning
   namespace: immich
-  labels:
-    app: immich-machine-learning
-    component: ml
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: immich-machine-learning
-      component: ml
   template:
     metadata:
       labels:
         app: immich-machine-learning
-        component: ml
     spec:
       securityContext:
         runAsNonRoot: true
@@ -59,22 +54,3 @@ spec:
           hostPath:
             path: /home/nas/shared/pvcs/immich/ml-cache
             type: DirectoryOrCreate
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: immich-machine-learning
-  namespace: immich
-  labels:
-    app: immich-machine-learning
-    component: ml
-spec:
-  selector:
-    app: immich-machine-learning
-    component: ml
-  ports:
-    - name: http
-      port: 3003
-      targetPort: 3003
-      protocol: TCP
-  type: ClusterIP

--- a/kubernetes/immich/deployment-server.yaml
+++ b/kubernetes/immich/deployment-server.yaml
@@ -3,20 +3,15 @@ kind: Deployment
 metadata:
   name: immich-server
   namespace: immich
-  labels:
-    app: immich-server
-    component: server
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: immich-server
-      component: server
   template:
     metadata:
       labels:
         app: immich-server
-        component: server
     spec:
       securityContext:
         runAsNonRoot: true
@@ -71,7 +66,7 @@ spec:
       volumes:
         - name: upload-storage
           hostPath:
-            path: /home/nas/media/immich/upload
+            path: /home/nas/shared/pvcs/immich/upload
             type: DirectoryOrCreate
         - name: localtime
           hostPath:

--- a/kubernetes/immich/deployment-server.yaml
+++ b/kubernetes/immich/deployment-server.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: immich-server
+  namespace: immich
+  labels:
+    app: immich-server
+    component: server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: immich-server
+      component: server
+  template:
+    metadata:
+      labels:
+        app: immich-server
+        component: server
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101000
+        runAsGroup: 110000
+        fsGroup: 110000
+      containers:
+        - name: immich-server
+          image: ghcr.io/immich-app/immich-server:release
+          ports:
+            - containerPort: 2283
+              name: http
+          envFrom:
+            - configMapRef:
+                name: immich-config
+          env:
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: immich-database-password
+                  key: password
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: immich-redis-auth
+                  key: password
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "500m"
+            limits:
+              memory: "2Gi"
+              cpu: "2"
+          volumeMounts:
+            - name: upload-storage
+              mountPath: /usr/src/app/upload
+            - name: localtime
+              mountPath: /etc/localtime
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /api/server-info/ping
+              port: 2283
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /api/server-info/ping
+              port: 2283
+            initialDelaySeconds: 10
+            periodSeconds: 10
+      volumes:
+        - name: upload-storage
+          hostPath:
+            path: /home/nas/media/immich/upload
+            type: DirectoryOrCreate
+        - name: localtime
+          hostPath:
+            path: /etc/localtime
+            type: File

--- a/kubernetes/immich/httproute.yaml
+++ b/kubernetes/immich/httproute.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: immich
+  namespace: immich
+  labels:
+    app: immich
+spec:
+  parentRefs:
+    - name: gateway
+      namespace: envoy-gateway-system
+  hostnames:
+    - "immich.weinbender.io"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: immich-server
+          port: 2283

--- a/kubernetes/immich/httproute.yaml
+++ b/kubernetes/immich/httproute.yaml
@@ -3,8 +3,6 @@ kind: HTTPRoute
 metadata:
   name: immich
   namespace: immich
-  labels:
-    app: immich
 spec:
   parentRefs:
     - name: gateway

--- a/kubernetes/immich/kustomization.yaml
+++ b/kubernetes/immich/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - deployment-server.yaml
   - deployment-ml.yaml
   - service.yaml
+  - service-ml.yaml
   - httproute.yaml
 
 commonLabels:

--- a/kubernetes/immich/kustomization.yaml
+++ b/kubernetes/immich/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: immich
+
+resources:
+  - configmap.yaml
+  - secrets.yaml
+  - deployment-server.yaml
+  - deployment-ml.yaml
+  - service.yaml
+  - httproute.yaml
+
+commonLabels:
+  app.kubernetes.io/name: immich
+  app.kubernetes.io/part-of: immich

--- a/kubernetes/immich/secrets.yaml
+++ b/kubernetes/immich/secrets.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: immich-database-password
+  namespace: immich
+  annotations:
+    "k8s-secrets-sync.weinbender.io/provider": "op"
+    "k8s-secrets-sync.weinbender.io/secret-key": "password"
+    "k8s-secrets-sync.weinbender.io/ref": "op://microk8s/immich-db/password"
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: immich-redis-auth
+  namespace: immich
+  annotations:
+    "k8s-secrets-sync.weinbender.io/provider": "op"
+    "k8s-secrets-sync.weinbender.io/secret-key": "password"
+    "k8s-secrets-sync.weinbender.io/ref": "op://microk8s/redis-users/immich-password"
+type: Opaque

--- a/kubernetes/immich/service-ml.yaml
+++ b/kubernetes/immich/service-ml.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: immich-server
+  name: immich-machine-learning
   namespace: immich
 spec:
   selector:
-    app: immich-server
+    app: immich-machine-learning
   ports:
     - name: http
-      port: 2283
-      targetPort: 2283
+      port: 3003
+      targetPort: 3003
       protocol: TCP
   type: ClusterIP

--- a/kubernetes/immich/service.yaml
+++ b/kubernetes/immich/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: immich-server
+  namespace: immich
+  labels:
+    app: immich-server
+    component: server
+spec:
+  selector:
+    app: immich-server
+    component: server
+  ports:
+    - name: http
+      port: 2283
+      targetPort: 2283
+      protocol: TCP
+  type: ClusterIP


### PR DESCRIPTION
This pull request introduces Kubernetes manifests to deploy the Immich application, including its server and machine learning components, along with supporting configurations such as secrets, services, and routing. The changes are designed to enable a production-ready deployment of Immich within a Kubernetes environment.

### Deployment Configuration:

* [`kubernetes/immich/configmap.yaml`](diffhunk://#diff-abf6d18ec06990a5b692dd04a5f09878f1dbec3398360ac8f085ee35adab236eR1-R29): Added a `ConfigMap` to define environment variables for database, Redis, machine learning service, logging, and server configuration.
* [`kubernetes/immich/deployment-server.yaml`](diffhunk://#diff-334130d200ac33a68e5f2aaa875ccd8f6110f783803b5a512ba0671e97497d3cR1-R79): Added a `Deployment` for the Immich server, specifying container configuration, environment variables sourced from the `ConfigMap` and secrets, resource limits, and probes for liveness and readiness.
* [`kubernetes/immich/deployment-ml.yaml`](diffhunk://#diff-4fbcf058723d0e152855e317d051ad99aa6764b719f866f7f26b0d1296a4a7a0R1-R80): Added a `Deployment` for the Immich machine learning service, including container configuration, resource limits, probes, and a volume for caching models.

### Networking and Routing:

* [`kubernetes/immich/service.yaml`](diffhunk://#diff-be47a1693170413814c44ef223d1de4578591c5a67b769612e2484f8c615a7c7R1-R18): Added a `Service` for the Immich server to expose it internally within the cluster.
* [`kubernetes/immich/httproute.yaml`](diffhunk://#diff-4baf4a95c15b338a3b56a259990f76aa0ce5ba0c457d6315ac1d3e100789ad2dR1-R21): Added an `HTTPRoute` to define external routing for the Immich server, specifying the hostname and backend service.

### Secrets Management:

* [`kubernetes/immich/secrets.yaml`](diffhunk://#diff-b7b5afab06419bacdbfccbb16b8d489754ad29cff87179c7bfad7d67337830d0R1-R21): Added `Secret` manifests for securely storing database and Redis passwords, with annotations for syncing secrets from an external provider.

### Organizational Enhancements:

* [`kubernetes/immich/kustomization.yaml`](diffhunk://#diff-e5e815d2a6d6f699c9c1069ec7acdb74db957dd28ca0c4bcbec1ce9f62e84161R1-R16): Added a `Kustomization` file to organize and manage all Kubernetes resources for the Immich application under a single namespace with common labels.